### PR TITLE
fix: Configure database initialization

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,12 +6,12 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
-    defer-datasource-initialization: true
   sql:
     init:
-      mode: never
+      mode: always
+  defer-datasource-initialization: true


### PR DESCRIPTION
Modify application.yml to ensure Hibernate creates the schema before data.sql is executed.

- Set spring.jpa.hibernate.ddl-auto to 'create' to enable schema creation on startup.
- Set spring.sql.init.mode to 'always' to ensure data.sql is run.
- Keep spring.jpa.defer-datasource-initialization set to true to make sure the data script runs after JPA setup.